### PR TITLE
site passthru calls ecp5.passthru()

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,9 @@ it also accepts "site" command to read file from ESP32 local filesystem
     ftp> site filename.bit
     ... will program local file to FPGA using
     ... ecp5.prog("filename.bit")
+    ftp> site passthru
+    ... will program file "passthru%08X.bit.gz" % idcode
+    ... ecp5.passhtru()
 
 SD card with FAT filesystem can be mounted or unmounted to "/sd" directory:
 

--- a/uftpd.py
+++ b/uftpd.py
@@ -431,6 +431,9 @@ class FTP_client:
                   cl.sendall('250 OK\r\n')
                 else:
                   cl.sendall('550 Fail\r\n')
+              elif path == "/passthru":
+                ecp5.passthru()
+                cl.sendall('250 OK passthru\r\n')
               else:
                 try:
                     if ecp5.prog(path, prog_close=False):


### PR DESCRIPTION
This is useful to get back serial console on esp32 if only ftp connection is available because current fpga image uses serial port