### PR TITLE
wait for wifi network before starting ftp server

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,10 @@
 # example main.py to connect at boot
 import network
 sta_if = network.WLAN(network.STA_IF)
-sta_if.active(True)
-sta_if.connect("accesspoint", "password")
+if not sta_if.isconnected():
+    sta_if.active(True)
+    sta_if.connect("accesspoint", "password")
+    while not sta_if.isconnected():
+            pass
+print('network config:', sta_if.ifconfig())
+import uftpd


### PR DESCRIPTION
This ensures that ftp server is available after power cycle without
restarting micropython over serial console