### PR TITLE
Enable support for AP/STA at the same time

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,10 +1,13 @@
 # example main.py to connect at boot
 import network
+# sta_if = client interface, ap_if = ap interface
 sta_if = network.WLAN(network.STA_IF)
-if not sta_if.isconnected():
-    sta_if.active(True)
-    sta_if.connect("accesspoint", "password")
-    while not sta_if.isconnected():
-            pass
+sta_if.active(True)
+sta_if.connect("accesspoint", "password")
+ap_if = network.WLAN(network.AP_IF)
+ap_if.active(True)
+ap_if.config(authmode=3, essid="ulx3s", password="Radiona123")
+print('AP config: ', ap_if.ifconfig())
 print('network config:', sta_if.ifconfig())
+# start uftpd by default
 import uftpd


### PR DESCRIPTION
Both STA and AP mode can work at the same time.
If somebody needs only single mode, it can remove
lines for specific mode.
It is also possible to disable single mode temporarily by
saying: ```sta_if.disconnect()```
(useful for disabling error messages as well)