### PR TITLE
Fix http port

### DIFF
--- a/ecp5.py
+++ b/ecp5.py
@@ -501,6 +501,7 @@ def open_web(url, gz=False):
   port = 80
   if ( len(host.split(':')) == 2 ):
     host, port = host.split(':', 2)
+    port = int(port)
   print("host = %s, port = %d, path = %s" % (host, port, path))
   addr = socket.getaddrinfo(host, port)[0][-1]
   s = socket.socket()


### PR DESCRIPTION
cast 'port' str to int

    >>> import ecp5
    >>> ecp5.prog("http://192.168.1.1:8080/blink_85f.bit")
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "ecp5.py", line 627, in prog
      File "ecp5.py", line 621, in filedata_gz
      File "ecp5.py", line 504, in open_web
    TypeError: can't convert str to int